### PR TITLE
WIP: Initial application structure and endpoint

### DIFF
--- a/cli-app/cmd/cli-app/main.go
+++ b/cli-app/cmd/cli-app/main.go
@@ -1,0 +1,1 @@
+package main

--- a/cli-app/go.mod
+++ b/cli-app/go.mod
@@ -1,3 +1,3 @@
 module github.com/arielcr/go-event-driven-app/cli-app
 
-go 1.20
+go 1.21

--- a/cli-app/go.mod
+++ b/cli-app/go.mod
@@ -1,0 +1,3 @@
+module github.com/arielcr/go-event-driven-app/cli-app
+
+go 1.20

--- a/event-consumer-service/cmd/event-consumer/main.go
+++ b/event-consumer-service/cmd/event-consumer/main.go
@@ -1,0 +1,1 @@
+package main

--- a/event-consumer-service/go.mod
+++ b/event-consumer-service/go.mod
@@ -1,0 +1,3 @@
+module github.com/arielcr/go-event-driven-app/event-consumer-service
+
+go 1.20

--- a/event-consumer-service/go.mod
+++ b/event-consumer-service/go.mod
@@ -1,3 +1,3 @@
 module github.com/arielcr/go-event-driven-app/event-consumer-service
 
-go 1.20
+go 1.21

--- a/event-processor-service/cmd/event-processor/main.go
+++ b/event-processor-service/cmd/event-processor/main.go
@@ -1,0 +1,25 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/gorilla/mux"
+
+	"github.com/arielcr/go-event-driven-app/event-processor-service/internal/application"
+)
+
+func main() {
+
+	fmt.Println("- Event Processor Service -")
+
+	router := mux.NewRouter()
+
+	a := new(application.App)
+
+	a.Initialize(
+		router,
+	)
+
+	a.Run(":8091")
+
+}

--- a/event-processor-service/cmd/event-processor/main.go
+++ b/event-processor-service/cmd/event-processor/main.go
@@ -1,24 +1,13 @@
 package main
 
 import (
-	"fmt"
-
-	"github.com/gorilla/mux"
-
 	"github.com/arielcr/go-event-driven-app/event-processor-service/internal/application"
 )
 
 func main() {
+	a := application.NewService()
 
-	fmt.Println("- Event Processor Service -")
-
-	router := mux.NewRouter()
-
-	a := new(application.App)
-
-	a.Initialize(
-		router,
-	)
+	a.Initialize()
 
 	a.Run(":8091")
 

--- a/event-processor-service/go.mod
+++ b/event-processor-service/go.mod
@@ -1,0 +1,5 @@
+module github.com/arielcr/go-event-driven-app/event-processor-service
+
+go 1.20
+
+require github.com/gorilla/mux v1.8.0 // indirect

--- a/event-processor-service/go.mod
+++ b/event-processor-service/go.mod
@@ -1,5 +1,10 @@
 module github.com/arielcr/go-event-driven-app/event-processor-service
 
-go 1.20
+go 1.21
 
-require github.com/gorilla/mux v1.8.0 // indirect
+require (
+	github.com/gorilla/mux v1.8.0
+	github.com/sirupsen/logrus v1.9.3
+)
+
+require golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8 // indirect

--- a/event-processor-service/go.sum
+++ b/event-processor-service/go.sum
@@ -1,0 +1,2 @@
+github.com/gorilla/mux v1.8.0 h1:i40aqfkR1h2SlN9hojwV5ZA91wcXFOvkdNIeFDP5koI=
+github.com/gorilla/mux v1.8.0/go.mod h1:DVbg23sWSpFRCP0SfiEN6jmj59UnW/n46BH5rLB71So=

--- a/event-processor-service/go.sum
+++ b/event-processor-service/go.sum
@@ -1,2 +1,17 @@
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/gorilla/mux v1.8.0 h1:i40aqfkR1h2SlN9hojwV5ZA91wcXFOvkdNIeFDP5koI=
 github.com/gorilla/mux v1.8.0/go.mod h1:DVbg23sWSpFRCP0SfiEN6jmj59UnW/n46BH5rLB71So=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/sirupsen/logrus v1.9.3 h1:dueUQJ1C2q9oE3F7wvmSGAaVtTmUizReu6fjN8uqzbQ=
+github.com/sirupsen/logrus v1.9.3/go.mod h1:naHLuLoDiP4jHNo9R0sCBMtWGeIprob74mVsIT4qYEQ=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
+github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8 h1:0A+M6Uqn+Eje4kHMK80dtF3JCXC4ykBgQG4Fe06QRhQ=
+golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/event-processor-service/internal/application/app.go
+++ b/event-processor-service/internal/application/app.go
@@ -1,0 +1,52 @@
+package application
+
+import (
+	"encoding/json"
+	"log"
+	"net/http"
+
+	"github.com/arielcr/go-event-driven-app/event-processor-service/internal/events"
+	"github.com/gorilla/mux"
+)
+
+type App struct {
+	Router *mux.Router
+}
+
+func (a *App) Initialize(r *mux.Router) {
+	a.Router = r
+
+	a.InitializeRoutes()
+}
+
+func (a *App) InitializeRoutes() {
+	a.Router.HandleFunc("/event", a.storeEvent).Methods("POST")
+}
+
+func (a *App) Run(addr string) {
+	log.Printf("Service Initialized at port %s...\n", addr)
+	log.Fatal(http.ListenAndServe(addr, a.Router))
+}
+
+func (a *App) storeEvent(w http.ResponseWriter, r *http.Request) {
+	var e events.Event
+	decoder := json.NewDecoder(r.Body)
+	if err := decoder.Decode(&e); err != nil {
+		respondWithError(w, http.StatusBadRequest, "Invalid request payload")
+		return
+	}
+	defer r.Body.Close()
+
+	respondWithJSON(w, http.StatusCreated, e)
+}
+
+func respondWithError(w http.ResponseWriter, code int, message string) {
+	respondWithJSON(w, code, map[string]string{"error": message})
+}
+
+func respondWithJSON(w http.ResponseWriter, code int, payload interface{}) {
+	response, _ := json.Marshal(payload)
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(code)
+	w.Write(response)
+}

--- a/event-processor-service/internal/events/model.go
+++ b/event-processor-service/internal/events/model.go
@@ -1,0 +1,11 @@
+package events
+
+type Event struct {
+	EventType string    `json:"event_type"`
+	EventData EventData `json:"event_data"`
+}
+
+type EventData struct {
+	Client  string `json:"client"`
+	Product string `json:"product"`
+}


### PR DESCRIPTION
- Mono repo folder structure for internal services: `cli-app`, `event-consumer-service`, `event-processor-service`
- Initial implementation for the `/event` endpoint in `event-processor-service`. This is just a placeholder for the moment, but can be accessed and return an empty success response